### PR TITLE
Combine search friends and search groups to one single API.

### DIFF
--- a/Kahla.Server/Controllers/FriendshipController.cs
+++ b/Kahla.Server/Controllers/FriendshipController.cs
@@ -161,17 +161,26 @@ namespace Kahla.Server.Controllers
             });
         }
 
-        public async Task<IActionResult> SearchFriends(SearchFriendsAddressModel model)
+        public async Task<IActionResult> SearchEverything(SearchEverythingAddressModel model)
         {
             var users = await _dbContext
                 .Users
                 .AsNoTracking()
-                .Where(t => t.NickName.Contains(model.NickName, StringComparison.CurrentCultureIgnoreCase))
+                .Where(t => t.NickName.Contains(model.SearchInput, StringComparison.CurrentCultureIgnoreCase))
                 .Take(model.Take)
                 .ToListAsync();
 
-            return this.AiurJson(new AiurCollection<KahlaUser>(users)
+            var groups = await _dbContext
+                .GroupConversations
+                .AsNoTracking()
+                .Where(t => t.GroupName.Contains(model.SearchInput, StringComparison.CurrentCultureIgnoreCase))
+                .Take(model.Take)
+                .ToListAsync();
+
+            return this.AiurJson(new SearchEverythingViewModel
             {
+                Users = users,
+                Groups = groups,
                 Code = ErrorType.Success,
                 Message = "Search result is shown."
             });

--- a/Kahla.Server/Controllers/GroupsController.cs
+++ b/Kahla.Server/Controllers/GroupsController.cs
@@ -31,22 +31,6 @@ namespace Kahla.Server.Controllers
             _dbContext = dbContext;
         }
 
-        public async Task<IActionResult> SearchGroup(SearchGroupAddressModel model)
-        {
-            var groups = await _dbContext
-                .GroupConversations
-                .AsNoTracking()
-                .Where(t => t.GroupName.Contains(model.GroupName, StringComparison.CurrentCultureIgnoreCase))
-                .Take(model.Take)
-                .ToListAsync();
-
-            return this.AiurJson(new AiurCollection<GroupConversation>(groups)
-            {
-                Code = ErrorType.Success,
-                Message = "Search result is shown."
-            });
-        }
-
         [HttpPost]
         public async Task<IActionResult> CreateGroupConversation(CreateGroupConversationAddressModel model)
         {

--- a/Kahla.Server/Migrations/KahlaDbContextModelSnapshot.cs
+++ b/Kahla.Server/Migrations/KahlaDbContextModelSnapshot.cs
@@ -4,12 +4,11 @@ using Kahla.Server.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Kahla.Server.Migrations
 {
     [DbContext(typeof(KahlaDbContext))]
-    partial class KahlaDbContextModelSnapshot : ModelSnapshot
+    public class KahlaDbContextModelSnapshot : ModelSnapshot
     {
         protected override void BuildModel(ModelBuilder modelBuilder)
         {

--- a/Kahla.Server/Models/ApiAddressModels/SearchEverythingAddressModel.cs
+++ b/Kahla.Server/Models/ApiAddressModels/SearchEverythingAddressModel.cs
@@ -2,11 +2,11 @@
 
 namespace Kahla.Server.Models.ApiAddressModels
 {
-    public class SearchFriendsAddressModel
+    public class SearchEverythingAddressModel
     {
         [MinLength(1)]
         [Required]
-        public string NickName { get; set; }
+        public string SearchInput { get; set; }
 
         public int Take { get; set; } = 20;
     }

--- a/Kahla.Server/Models/ApiAddressModels/UpdateClientSettingModel.cs
+++ b/Kahla.Server/Models/ApiAddressModels/UpdateClientSettingModel.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
+﻿using System.ComponentModel.DataAnnotations;
 
 namespace Kahla.Server.Models.ApiAddressModels
 {

--- a/Kahla.Server/Models/ApiViewModels/SearchEverythingViewModel.cs
+++ b/Kahla.Server/Models/ApiViewModels/SearchEverythingViewModel.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Aiursoft.Pylon.Models;
+
+namespace Kahla.Server.Models.ApiViewModels
+{
+    public class SearchEverythingViewModel : AiurProtocol
+    {
+        public List<KahlaUser> Users { get; set; }
+        public List<GroupConversation> Groups { get; set; }
+    }
+}


### PR DESCRIPTION
This changes our current server-side search system.

I have combined two search API, search friends and search groups to one single API. So that if the user wanna search something and he can have one search entry point.

So we may remove our `Search group` button and rename our `Search friends` button to `Search new`.

In this `search-new` component, the user can search for friends and groups with one input. And the page will show a second navigation bar to let him show friend search results or group search results.

<img width="396" alt="Untitled" src="https://user-images.githubusercontent.com/19531547/54881721-1f60a880-4e96-11e9-9571-d79d229c2420.png">


Do you agree with that new design? 