### PR TITLE
This pull request allows the user to set the conversation max message lifetime.

### DIFF
--- a/Kahla.Server/Controllers/ConversationController.cs
+++ b/Kahla.Server/Controllers/ConversationController.cs
@@ -183,6 +183,20 @@ namespace Kahla.Server.Controllers
             throw new InvalidOperationException("Target is:" + target.Discriminator);
         }
 
+        [HttpPost]
+        public async Task<IActionResult> UpdateMessageLifeTime(UpdateMessageLifeTimeAddressModel model)
+        {
+            var user = await GetKahlaUser();
+            var target = await _dbContext.Conversations.FindAsync(model.Id);
+            if (!await _dbContext.VerifyJoined(user.Id, target))
+                return this.Protocol(ErrorType.Unauthorized, "You don't have any relationship with that conversation.");
+            target.MaxLiveSeconds = model.NewLifeTime;
+            _dbContext.Update(target);
+            await _dbContext.SaveChangesAsync();
+            return this.Protocol(ErrorType.Success, "Successfully updated your life time. Your current message life time is: " + 
+                TimeSpan.FromSeconds(target.MaxLiveSeconds));
+        }
+
         private Task<KahlaUser> GetKahlaUser()
         {
             return _userManager.GetUserAsync(User);

--- a/Kahla.Server/Controllers/ConversationController.cs
+++ b/Kahla.Server/Controllers/ConversationController.cs
@@ -190,8 +190,8 @@ namespace Kahla.Server.Controllers
             var target = await _dbContext.Conversations.FindAsync(model.Id);
             if (!await _dbContext.VerifyJoined(user.Id, target))
                 return this.Protocol(ErrorType.Unauthorized, "You don't have any relationship with that conversation.");
+            // Do update.
             target.MaxLiveSeconds = model.NewLifeTime;
-            _dbContext.Update(target);
             await _dbContext.SaveChangesAsync();
             return this.Protocol(ErrorType.Success, "Successfully updated your life time. Your current message life time is: " + 
                 TimeSpan.FromSeconds(target.MaxLiveSeconds));

--- a/Kahla.Server/Controllers/FriendshipController.cs
+++ b/Kahla.Server/Controllers/FriendshipController.cs
@@ -187,8 +187,12 @@ namespace Kahla.Server.Controllers
         public async Task<IActionResult> DiscoverFriends(int take = 15)
         {
             // Load everything to memory and even functions.
-            var users = await _dbContext.Users.ToListAsync();
-            var conversations = await _dbContext.PrivateConversations.ToListAsync();
+            var users = await _dbContext.Users
+                .AsNoTracking()
+                .ToListAsync();
+            var conversations = await _dbContext.PrivateConversations
+                .AsNoTracking()
+                .ToListAsync();
             bool AreFriends(string userId1, string userId2)
             {
                 var relation = conversations.Any(t => t.RequesterId == userId1 && t.TargetId == userId2);

--- a/Kahla.Server/Migrations/20190327041219_AddMessageLiveTimeForConversation.Designer.cs
+++ b/Kahla.Server/Migrations/20190327041219_AddMessageLiveTimeForConversation.Designer.cs
@@ -4,14 +4,16 @@ using Kahla.Server.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Kahla.Server.Migrations
 {
     [DbContext(typeof(KahlaDbContext))]
-    partial class KahlaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20190327041219_AddMessageLiveTimeForConversation")]
+    partial class AddMessageLiveTimeForConversation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Kahla.Server/Migrations/20190327041219_AddMessageLiveTimeForConversation.cs
+++ b/Kahla.Server/Migrations/20190327041219_AddMessageLiveTimeForConversation.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Kahla.Server.Migrations
+{
+    public partial class AddMessageLiveTimeForConversation : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "MaxLiveSeconds",
+                table: "Conversations",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MaxLiveSeconds",
+                table: "Conversations");
+        }
+    }
+}

--- a/Kahla.Server/Models/ApiAddressModels/UpdateMessageLifeTimeAddressModel.cs
+++ b/Kahla.Server/Models/ApiAddressModels/UpdateMessageLifeTimeAddressModel.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Kahla.Server.Models.ApiAddressModels
+{
+    public class UpdateMessageLifeTimeAddressModel
+    {
+        // Conversation Id
+        public int Id { get; set; }
+
+        [Range(5, int.MaxValue)]
+        public int NewLifeTime { get; set; }
+    }
+}

--- a/Kahla.Server/Models/Conversation.cs
+++ b/Kahla.Server/Models/Conversation.cs
@@ -10,10 +10,9 @@ namespace Kahla.Server.Models
     {
         [Key]
         public int Id { get; set; }
-
         public string Discriminator { get; set; }
-
         public string AESKey { get; set; }
+        public int MaxLiveSeconds { get; set; } = int.MaxValue;
         [JsonIgnore]
         [InverseProperty(nameof(Message.Conversation))]
         public IEnumerable<Message> Messages { get; set; }


### PR DESCRIPTION
### Server will check all messages every 1 minute.

If the server found any messages out of its lifetime, the server will delete it directly!

### Creat a new API to update the lifetime.

Lifetime is a number, represents seconds, from 5 to 50 years. Only users in that conversation could update it.

### When calling `Conversation details` API, will return lifetime.

When calling `Conversation details` API, will return lifetime.

### When selecting messages, only messages alive can be selected

Which means there will be no push messages when your message was deleted! So in the app side, when the user opens the talking page and the app can load the conversation message max time.

The talking page shall only display the messages in life. Which means with time elapse, the messages shall disappear automatically.