### PR TITLE
Secret token can download 100 times.

### DIFF
--- a/Kahla.Server/Controllers/FilesController.cs
+++ b/Kahla.Server/Controllers/FilesController.cs
@@ -147,7 +147,7 @@ namespace Kahla.Server.Controllers
             {
                 return this.Protocol(ErrorType.Unauthorized, $"You are not authorized to download file from conversation: {record.Conversation.Id}!");
             }
-            var secret = await _secretService.GenerateAsync(record.FileKey, await _appsContainer.AccessToken(), 1);
+            var secret = await _secretService.GenerateAsync(record.FileKey, await _appsContainer.AccessToken(), 100);
             return Json(new FileDownloadAddressViewModel
             {
                 Code = ErrorType.Success,


### PR DESCRIPTION
This will temporary resolve the CDN reverse proxy 8MB issue.