### PR TITLE
Huge API change which means that the app may need to refactor....

### DIFF
--- a/Kahla.SDK/Abstract/BotBase.cs
+++ b/Kahla.SDK/Abstract/BotBase.cs
@@ -49,6 +49,8 @@ namespace Kahla.SDK.Abstract
 
         public virtual Task OnWasDeleted(WereDeletedEvent typedEvent) => Task.CompletedTask;
 
+        public virtual Task OnGroupDissolve(DissolveEvent typedEvent) => Task.CompletedTask;
+
         public async Task Start(bool enableCommander)
         {
             if (enableCommander)

--- a/Kahla.SDK/Abstract/BotBase.cs
+++ b/Kahla.SDK/Abstract/BotBase.cs
@@ -47,6 +47,8 @@ namespace Kahla.SDK.Abstract
 
         public virtual Task OnGroupInvitation(int groupId, NewMessageEvent eventContext) => Task.CompletedTask;
 
+        public virtual Task OnWasDeleted(WereDeletedEvent typedEvent) => Task.CompletedTask;
+
         public async Task Start(bool enableCommander)
         {
             if (enableCommander)
@@ -107,6 +109,7 @@ namespace Kahla.SDK.Abstract
             await MonitorEvents(websocketAddress);
             return;
         }
+
 
         public string AskServerAddress()
         {

--- a/Kahla.SDK/Abstract/BotBase.cs
+++ b/Kahla.SDK/Abstract/BotBase.cs
@@ -47,7 +47,7 @@ namespace Kahla.SDK.Abstract
 
         public virtual Task OnGroupInvitation(int groupId, NewMessageEvent eventContext) => Task.CompletedTask;
 
-        public virtual Task OnWasDeleted(WereDeletedEvent typedEvent) => Task.CompletedTask;
+        public virtual Task OnWasDeleted(FriendDeletedEvent typedEvent) => Task.CompletedTask;
 
         public virtual Task OnGroupDissolve(DissolveEvent typedEvent) => Task.CompletedTask;
 

--- a/Kahla.SDK/Data/EventSyncer.cs
+++ b/Kahla.SDK/Data/EventSyncer.cs
@@ -44,11 +44,11 @@ namespace Kahla.SDK.Data
         {
             _websocket = client;
             _bot = bot;
-            await Clone();
+            await SyncFromServer();
             client.MessageReceived.Subscribe(OnStargateMessage);
         }
 
-        public async Task Clone()
+        public async Task SyncFromServer()
         {
             var allResponse = await _conversationService.AllAsync();
             Contacts = allResponse.Items;
@@ -91,10 +91,7 @@ namespace Kahla.SDK.Data
             {
                 await _bot.OnGroupInvitation(groupId, typedEvent);
             }
-            else
-            {
-                await _bot.OnMessage(decrypted, typedEvent).ConfigureAwait(false);
-            }
+            await _bot.OnMessage(decrypted, typedEvent).ConfigureAwait(false);
         }
 
         public void PatchFriendRequest(Request request)

--- a/Kahla.SDK/Data/EventSyncer.cs
+++ b/Kahla.SDK/Data/EventSyncer.cs
@@ -61,6 +61,10 @@ namespace Kahla.SDK.Data
             {
                 case EventType.NewMessage:
                     var newMessageEvent = JsonConvert.DeserializeObject<NewMessageEvent>(msg.ToString());
+                    InsertNewMessage(
+                        newMessageEvent.ConversationId,
+                        newMessageEvent.Message,
+                        newMessageEvent.Mentioned);
                     await OnNewMessageEvent(newMessageEvent);
                     break;
                 case EventType.NewFriendRequestEvent:
@@ -130,6 +134,15 @@ namespace Kahla.SDK.Data
                 {
                     inMemory = request;
                 }
+            }
+        }
+
+        public void InsertNewMessage(int conversationId, Message message, bool mentioned)
+        {
+            if (!Contacts.Any(t => t.ConversationId == conversationId))
+            {
+                _botLogger.LogDanger($"Comming new message from conversation: '{conversationId}' but we can't find it in memory.");
+                return;
             }
         }
 

--- a/Kahla.SDK/Data/EventSyncer.cs
+++ b/Kahla.SDK/Data/EventSyncer.cs
@@ -60,32 +60,34 @@ namespace Kahla.SDK.Data
         public async void OnStargateMessage(ResponseMessage msg)
         {
             var inevent = JsonConvert.DeserializeObject<KahlaEvent>(msg.ToString());
-            if (inevent.Type == EventType.NewMessage)
+            switch (inevent.Type)
             {
-                var typedEvent = JsonConvert.DeserializeObject<NewMessageEvent>(msg.ToString());
-                await OnNewMessageEvent(typedEvent);
-            }
-            else if (inevent.Type == EventType.NewFriendRequestEvent)
-            {
-                var typedEvent = JsonConvert.DeserializeObject<NewFriendRequestEvent>(msg.ToString());
-                PatchFriendRequest(typedEvent.Request);
-                await _bot.OnFriendRequest(typedEvent);
-            }
-            else if (inevent.Type == EventType.FriendsChangedEvent)
-            {
-                var typedEvent = JsonConvert.DeserializeObject<FriendsChangedEvent>(msg.ToString());
-                PatchFriendRequest(typedEvent.Request);
-                if (typedEvent.Result)
-                {
-                    SyncFriendRequestToContacts(typedEvent.Request, typedEvent.CreatedConversation);
-                }
-                await _bot.OnFriendsChangedEvent(typedEvent);
-            }
-            else if (inevent.Type == EventType.WereDeletedEvent)
-            {
-                var typedEvent = JsonConvert.DeserializeObject<WereDeletedEvent>(msg.ToString());
-                DeleteConversationIfExist(typedEvent.ConversationId);
-                await _bot.OnWasDeleted(typedEvent);
+                case EventType.NewMessage:
+                    var newMessageEvent = JsonConvert.DeserializeObject<NewMessageEvent>(msg.ToString());
+                    await OnNewMessageEvent(newMessageEvent);
+                    break;
+                case EventType.NewFriendRequestEvent:
+                    var newFriendRequestEvent = JsonConvert.DeserializeObject<NewFriendRequestEvent>(msg.ToString());
+                    PatchFriendRequest(newFriendRequestEvent.Request);
+                    await _bot.OnFriendRequest(newFriendRequestEvent);
+                    break;
+                case EventType.FriendsChangedEvent:
+                    var friendsChangedEvent = JsonConvert.DeserializeObject<FriendsChangedEvent>(msg.ToString());
+                    PatchFriendRequest(friendsChangedEvent.Request);
+                    if (friendsChangedEvent.Result)
+                    {
+                        SyncFriendRequestToContacts(friendsChangedEvent.Request, friendsChangedEvent.CreatedConversation);
+                    }
+                    await _bot.OnFriendsChangedEvent(friendsChangedEvent);
+                    break;
+                case EventType.WereDeletedEvent:
+                    var wereDeletedEvent = JsonConvert.DeserializeObject<WereDeletedEvent>(msg.ToString());
+                    DeleteConversationIfExist(wereDeletedEvent.ConversationId);
+                    await _bot.OnWasDeleted(wereDeletedEvent);
+                    break;
+                default:
+                    _botLogger.LogDanger($"Unhandled server event: {inevent.TypeDescription}!");
+                    break;
             }
         }
 

--- a/Kahla.SDK/Data/EventSyncer.cs
+++ b/Kahla.SDK/Data/EventSyncer.cs
@@ -103,6 +103,11 @@ namespace Kahla.SDK.Data
                         // Some other one, not me, was deleted in a conversation.
                     }
                     break;
+                case EventType.GroupJoinedEvent:
+                    var groupJoinedEvent = JsonConvert.DeserializeObject<GroupJoinedEvent>(msg.ToString());
+                    SyncGroupToContacts(groupJoinedEvent.CreatedConversation);
+                    await _bot.OnGroupConnected(new SearchedGroup(groupJoinedEvent.CreatedConversation));
+                    break;
                 default:
                     _botLogger.LogDanger($"Unhandled server event: {inevent.TypeDescription}!");
                     break;
@@ -173,6 +178,25 @@ namespace Kahla.SDK.Data
                     request.Creator.IsOnline :
                     request.Target.IsOnline
             }); ;
+        }
+
+        public void SyncGroupToContacts(GroupConversation createdConversation)
+        {
+            Contacts.Add(new ContactInfo
+            {
+                AesKey = createdConversation.AESKey,
+                SomeoneAtMe = false,
+                UnReadAmount = 0, // This is not accurate.
+                ConversationId = createdConversation.Id,
+                Discriminator = nameof(GroupConversation),
+                DisplayImagePath = createdConversation.GroupImagePath,
+                DisplayName = createdConversation.GroupName,
+                EnableInvisiable = false,
+                LatestMessage = null,// This is not accurate.
+                Muted = false,
+                Online = false,
+                UserId = createdConversation.OwnerId
+            });
         }
 
         public void DeleteConversationIfExist(int conversationId)

--- a/Kahla.SDK/Data/EventSyncer.cs
+++ b/Kahla.SDK/Data/EventSyncer.cs
@@ -84,8 +84,8 @@ namespace Kahla.SDK.Data
             else if (inevent.Type == EventType.WereDeletedEvent)
             {
                 var typedEvent = JsonConvert.DeserializeObject<WereDeletedEvent>(msg.ToString());
-                typedEvent.Trigger
-
+                DeleteConversationIfExist(typedEvent.ConversationId);
+                await _bot.OnWasDeleted(typedEvent);
             }
         }
 
@@ -144,6 +144,14 @@ namespace Kahla.SDK.Data
                     request.Creator.IsOnline :
                     request.Target.IsOnline
             }); ;
+        }
+
+        public void DeleteConversationIfExist(int conversationId)
+        {
+            if (Contacts.Any(t => t.ConversationId == conversationId))
+            {
+                Contacts.RemoveAll(t => t.ConversationId == conversationId);
+            }
         }
     }
 }

--- a/Kahla.SDK/Data/EventSyncer.cs
+++ b/Kahla.SDK/Data/EventSyncer.cs
@@ -81,6 +81,12 @@ namespace Kahla.SDK.Data
                 }
                 await _bot.OnFriendsChangedEvent(typedEvent);
             }
+            else if (inevent.Type == EventType.WereDeletedEvent)
+            {
+                var typedEvent = JsonConvert.DeserializeObject<WereDeletedEvent>(msg.ToString());
+                typedEvent.Trigger
+
+            }
         }
 
         public async Task OnNewMessageEvent(NewMessageEvent typedEvent)

--- a/Kahla.SDK/Data/EventSyncer.cs
+++ b/Kahla.SDK/Data/EventSyncer.cs
@@ -81,10 +81,10 @@ namespace Kahla.SDK.Data
                     }
                     await _bot.OnFriendsChangedEvent(friendsChangedEvent);
                     break;
-                case EventType.WereDeletedEvent:
-                    var wereDeletedEvent = JsonConvert.DeserializeObject<WereDeletedEvent>(msg.ToString());
-                    DeleteConversationIfExist(wereDeletedEvent.ConversationId);
-                    await _bot.OnWasDeleted(wereDeletedEvent);
+                case EventType.FriendDeletedEvent:
+                    var friendDeletedEvent = JsonConvert.DeserializeObject<FriendDeletedEvent>(msg.ToString());
+                    DeleteConversationIfExist(friendDeletedEvent.ConversationId);
+                    await _bot.OnWasDeleted(friendDeletedEvent);
                     break;
                 case EventType.DissolveEvent:
                     var dissolveEvent = JsonConvert.DeserializeObject<DissolveEvent>(msg.ToString());

--- a/Kahla.SDK/Data/EventSyncer.cs
+++ b/Kahla.SDK/Data/EventSyncer.cs
@@ -105,7 +105,7 @@ namespace Kahla.SDK.Data
                     break;
                 case EventType.GroupJoinedEvent:
                     var groupJoinedEvent = JsonConvert.DeserializeObject<GroupJoinedEvent>(msg.ToString());
-                    SyncGroupToContacts(groupJoinedEvent.CreatedConversation);
+                    SyncGroupToContacts(groupJoinedEvent.CreatedConversation, groupJoinedEvent.MessageCount, groupJoinedEvent.LatestMessage);
                     await _bot.OnGroupConnected(new SearchedGroup(groupJoinedEvent.CreatedConversation));
                     break;
                 default:
@@ -180,19 +180,19 @@ namespace Kahla.SDK.Data
             }); ;
         }
 
-        public void SyncGroupToContacts(GroupConversation createdConversation)
+        public void SyncGroupToContacts(GroupConversation createdConversation, int messageCount, Message latestMessage)
         {
             Contacts.Add(new ContactInfo
             {
                 AesKey = createdConversation.AESKey,
                 SomeoneAtMe = false,
-                UnReadAmount = 0, // This is not accurate.
+                UnReadAmount = messageCount,
                 ConversationId = createdConversation.Id,
                 Discriminator = nameof(GroupConversation),
                 DisplayImagePath = createdConversation.GroupImagePath,
                 DisplayName = createdConversation.GroupName,
                 EnableInvisiable = false,
-                LatestMessage = null,// This is not accurate.
+                LatestMessage = latestMessage,
                 Muted = false,
                 Online = false,
                 UserId = createdConversation.OwnerId

--- a/Kahla.SDK/Events/KahlaEvent.cs
+++ b/Kahla.SDK/Events/KahlaEvent.cs
@@ -36,6 +36,10 @@ namespace Kahla.SDK.Events
         /// When the group owner dissolved the group.
         /// </summary>
         DissolveEvent = 7,
+        /// <summary>
+        /// When you successfully joined a group.
+        /// </summary>
+        GroupJoinedEvent = 8
     }
     public class KahlaEvent
     {
@@ -51,6 +55,9 @@ namespace Kahla.SDK.Events
         }
         public string AESKey { get; set; }
         public bool Muted { get; set; }
+        /// <summary>
+        /// If you was mentioned in this message.
+        /// </summary>
         public bool Mentioned { get; set; }
         public int ConversationId => Message.ConversationId;
         public Message Message { get; set; }

--- a/Kahla.SDK/Events/KahlaEvent.cs
+++ b/Kahla.SDK/Events/KahlaEvent.cs
@@ -15,7 +15,7 @@ namespace Kahla.SDK.Events
         /// <summary>
         /// When you was deleted by a friend or you deleted a friend.
         /// </summary>
-        WereDeletedEvent = 2,
+        FriendDeletedEvent = 2,
         /// <summary>
         /// When one of friend request related to you was completed.
         /// </summary>
@@ -85,11 +85,11 @@ namespace Kahla.SDK.Events
         public PrivateConversation CreatedConversation { get; set; }
     }
 
-    public class WereDeletedEvent : KahlaEvent
+    public class FriendDeletedEvent : KahlaEvent
     {
-        public WereDeletedEvent()
+        public FriendDeletedEvent()
         {
-            Type = EventType.WereDeletedEvent;
+            Type = EventType.FriendDeletedEvent;
         }
 
         public KahlaUser Trigger { get; set; }

--- a/Kahla.SDK/Events/KahlaEvent.cs
+++ b/Kahla.SDK/Events/KahlaEvent.cs
@@ -144,5 +144,7 @@ namespace Kahla.SDK.Events
         }
 
         public GroupConversation CreatedConversation { get; set; }
+        public Message LatestMessage { get; set; }
+        public int MessageCount { get; set; }
     }
 }

--- a/Kahla.SDK/Events/KahlaEvent.cs
+++ b/Kahla.SDK/Events/KahlaEvent.cs
@@ -1,5 +1,4 @@
 ﻿using Kahla.SDK.Models;
-using Kahla.SDK.Models.ApiViewModels;
 
 namespace Kahla.SDK.Events
 {
@@ -144,6 +143,6 @@ namespace Kahla.SDK.Events
             Type = EventType.GroupJoinedEvent;
         }
 
-        public ContactInfo CreatedContact { get; set; }
+        public GroupConversation CreatedConversation { get; set; }
     }
 }

--- a/Kahla.SDK/Events/KahlaEvent.cs
+++ b/Kahla.SDK/Events/KahlaEvent.cs
@@ -4,8 +4,17 @@ namespace Kahla.SDK.Events
 {
     public enum EventType
     {
+        /// <summary>
+        /// When some one sent you a new message.
+        /// </summary>
         NewMessage = 0,
+        /// <summary>
+        /// When a friend request related to you was created.
+        /// </summary>
         NewFriendRequestEvent = 1,
+        /// <summary>
+        /// When you was deleted by a friend or you deleted a friend.
+        /// </summary>
         WereDeletedEvent = 2,
         FriendsChangedEvent = 3,
         TimerUpdatedEvent = 4,

--- a/Kahla.SDK/Events/KahlaEvent.cs
+++ b/Kahla.SDK/Events/KahlaEvent.cs
@@ -16,10 +16,25 @@ namespace Kahla.SDK.Events
         /// When you was deleted by a friend or you deleted a friend.
         /// </summary>
         WereDeletedEvent = 2,
+        /// <summary>
+        /// When one of friend request related to you was completed.
+        /// </summary>
         FriendsChangedEvent = 3,
+        /// <summary>
+        /// When the timer of one of the conversations you joined was changed.
+        /// </summary>
         TimerUpdatedEvent = 4,
+        /// <summary>
+        /// When some one joined a group you joined.
+        /// </summary>
         NewMemberEvent = 5,
+        /// <summary>
+        /// When some one left a group you joined or kicked out of a group.
+        /// </summary>
         SomeoneLeftEvent = 6,
+        /// <summary>
+        /// When the group owner dissolved the group.
+        /// </summary>
         DissolveEvent = 7,
     }
     public class KahlaEvent

--- a/Kahla.SDK/Events/KahlaEvent.cs
+++ b/Kahla.SDK/Events/KahlaEvent.cs
@@ -60,9 +60,10 @@ namespace Kahla.SDK.Events
         {
             Type = EventType.WereDeletedEvent;
         }
-        public KahlaUser Trigger { get; set; }
-    }
 
+        public KahlaUser Trigger { get; set; }
+        public int ConversationId { get; set; }
+    }
 
     public class TimerUpdatedEvent : KahlaEvent
     {

--- a/Kahla.SDK/Events/KahlaEvent.cs
+++ b/Kahla.SDK/Events/KahlaEvent.cs
@@ -1,4 +1,5 @@
 ﻿using Kahla.SDK.Models;
+using Kahla.SDK.Models.ApiViewModels;
 
 namespace Kahla.SDK.Events
 {
@@ -134,5 +135,15 @@ namespace Kahla.SDK.Events
         }
 
         public int ConversationId { get; set; }
+    }
+
+    public class GroupJoinedEvent : KahlaEvent
+    {
+        public GroupJoinedEvent()
+        {
+            Type = EventType.GroupJoinedEvent;
+        }
+
+        public ContactInfo CreatedContact { get; set; }
     }
 }

--- a/Kahla.Server/Controllers/FriendshipController.cs
+++ b/Kahla.Server/Controllers/FriendshipController.cs
@@ -73,6 +73,9 @@ namespace Kahla.Server.Controllers
         public async Task<IActionResult> DeleteFriend([Required]string id)
         {
             var user = await GetKahlaUser();
+            await _dbContext.Entry(user)
+                .Collection(t => t.HisDevices)
+                .LoadAsync();
             var target = await _dbContext.Users.Include(t => t.HisDevices).SingleOrDefaultAsync(t => t.Id == id);
             if (target == null)
             {

--- a/Kahla.Server/Controllers/FriendshipController.cs
+++ b/Kahla.Server/Controllers/FriendshipController.cs
@@ -82,9 +82,9 @@ namespace Kahla.Server.Controllers
             {
                 return this.Protocol(ErrorType.NotEnoughResources, "He is not your friend at all.");
             }
-            await _dbContext.RemoveFriend(user.Id, target.Id);
+            var deletedConversationId = await _dbContext.RemoveFriend(user.Id, target.Id);
             await _dbContext.SaveChangesAsync();
-            await _pusher.WereDeletedEvent(target.CurrentChannel, target.HisDevices, user);
+            await _pusher.WereDeletedEvent(target.CurrentChannel, target.HisDevices, user, deletedConversationId);
             return this.Protocol(ErrorType.Success, "Successfully deleted your friend relationship.");
         }
 

--- a/Kahla.Server/Controllers/FriendshipController.cs
+++ b/Kahla.Server/Controllers/FriendshipController.cs
@@ -84,7 +84,10 @@ namespace Kahla.Server.Controllers
             }
             var deletedConversationId = await _dbContext.RemoveFriend(user.Id, target.Id);
             await _dbContext.SaveChangesAsync();
-            await _pusher.WereDeletedEvent(target.CurrentChannel, target.HisDevices, user, deletedConversationId);
+            await Task.WhenAll(
+                _pusher.WereDeletedEvent(target.CurrentChannel, target.HisDevices, user, deletedConversationId),
+                _pusher.WereDeletedEvent(user.CurrentChannel, user.HisDevices, user, deletedConversationId)
+            );
             return this.Protocol(ErrorType.Success, "Successfully deleted your friend relationship.");
         }
 

--- a/Kahla.Server/Controllers/FriendshipController.cs
+++ b/Kahla.Server/Controllers/FriendshipController.cs
@@ -88,8 +88,8 @@ namespace Kahla.Server.Controllers
             var deletedConversationId = await _dbContext.RemoveFriend(user.Id, target.Id);
             await _dbContext.SaveChangesAsync();
             await Task.WhenAll(
-                _pusher.WereDeletedEvent(target.CurrentChannel, target.HisDevices, user, deletedConversationId),
-                _pusher.WereDeletedEvent(user.CurrentChannel, user.HisDevices, user, deletedConversationId)
+                _pusher.FriendDeletedEvent(target.CurrentChannel, target.HisDevices, user, deletedConversationId),
+                _pusher.FriendDeletedEvent(user.CurrentChannel, user.HisDevices, user, deletedConversationId)
             );
             return this.Protocol(ErrorType.Success, "Successfully deleted your friend relationship.");
         }

--- a/Kahla.Server/Controllers/GroupsController.cs
+++ b/Kahla.Server/Controllers/GroupsController.cs
@@ -136,6 +136,10 @@ namespace Kahla.Server.Controllers
                 _dbContext.UserGroupRelations.Add(newRelationship);
                 _dbContext.SaveChanges();
             }
+            await _dbContext.Entry(user)
+                .Collection(t => t.HisDevices)
+                .LoadAsync();
+            await _pusher.GroupJoinedEvent(user, new ContactInfo());
             await group.ForEachUserAsync((eachUser, relation) => _pusher.NewMemberEvent(eachUser, user, group.Id));
             return Json(new AiurValue<int>(group.Id)
             {

--- a/Kahla.Server/Controllers/GroupsController.cs
+++ b/Kahla.Server/Controllers/GroupsController.cs
@@ -153,7 +153,7 @@ namespace Kahla.Server.Controllers
                 .OrderByDescending(t => t.SendTime)
                 .FirstOrDefaultAsync();
             await Task.WhenAll(
-                _pusher.GroupJoinedEvent(user, group),
+                _pusher.GroupJoinedEvent(user, group, latestMessage, messagesCount),
                 group.ForEachUserAsync((eachUser, relation) => _pusher.NewMemberEvent(eachUser, user, group.Id))
             );
             return Json(new AiurValue<int>(group.Id)

--- a/Kahla.Server/Controllers/GroupsController.cs
+++ b/Kahla.Server/Controllers/GroupsController.cs
@@ -153,21 +153,7 @@ namespace Kahla.Server.Controllers
                 .OrderByDescending(t => t.SendTime)
                 .FirstOrDefaultAsync();
             await Task.WhenAll(
-                _pusher.GroupJoinedEvent(user, new ContactInfo
-                {
-                    AesKey = group.AESKey,
-                    SomeoneAtMe = false,
-                    UnReadAmount = messagesCount,
-                    ConversationId = group.Id,
-                    Discriminator = nameof(GroupConversation),
-                    DisplayImagePath = group.GroupImagePath,
-                    DisplayName = group.GroupName,
-                    EnableInvisiable = false,
-                    LatestMessage = latestMessage,
-                    Muted = false,
-                    Online = false,
-                    UserId = group.OwnerId
-                }),
+                _pusher.GroupJoinedEvent(user, group),
                 group.ForEachUserAsync((eachUser, relation) => _pusher.NewMemberEvent(eachUser, user, group.Id))
             );
             return Json(new AiurValue<int>(group.Id)

--- a/Kahla.Server/Data/KahlaDbContext.cs
+++ b/Kahla.Server/Data/KahlaDbContext.cs
@@ -89,12 +89,21 @@ namespace Kahla.Server.Data
             return await FindConversationAsync(userId1, userId2) != null;
         }
 
-        public async Task RemoveFriend(string userId1, string userId2)
+        public async Task<int> RemoveFriend(string userId1, string userId2)
         {
             var relation = await PrivateConversations.SingleOrDefaultAsync(t => t.RequesterId == userId1 && t.TargetId == userId2);
             var belation = await PrivateConversations.SingleOrDefaultAsync(t => t.RequesterId == userId2 && t.TargetId == userId1);
-            if (relation != null) PrivateConversations.Remove(relation);
-            if (belation != null) PrivateConversations.Remove(belation);
+            if (relation != null)
+            {
+                PrivateConversations.Remove(relation);
+                return relation.Id;
+            }
+            if (belation != null)
+            {
+                PrivateConversations.Remove(belation);
+                return belation.Id;
+            }
+            return -1;
         }
 
         public async Task<GroupConversation> CreateGroup(string groupName, string creatorId, string joinPassword)

--- a/Kahla.Server/Services/KahlaPushService.cs
+++ b/Kahla.Server/Services/KahlaPushService.cs
@@ -4,6 +4,7 @@ using Aiursoft.SDK.Services;
 using Aiursoft.SDK.Services.ToStargateServer;
 using Kahla.SDK.Events;
 using Kahla.SDK.Models;
+using Kahla.SDK.Models.ApiViewModels;
 using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -92,16 +93,16 @@ namespace Kahla.Server.Services
         public async Task FriendDeletedEvent(int stargateChannel, IEnumerable<Device> devices, KahlaUser trigger, int deletedConversationId)
         {
             var token = await _appsContainer.AccessToken();
-            var wereDeletedEvent = new FriendDeletedEvent
+            var friendDeletedEvent = new FriendDeletedEvent
             {
                 Trigger = trigger,
                 ConversationId = deletedConversationId
             };
             if (stargateChannel != -1)
             {
-                await _stargatePushService.PushMessageAsync(token, stargateChannel, JsonConvert.SerializeObject(wereDeletedEvent), true);
+                await _stargatePushService.PushMessageAsync(token, stargateChannel, JsonConvert.SerializeObject(friendDeletedEvent), true);
             }
-            await _thirdPartyPushService.PushAsync(devices, "postermaster@aiursoft.com", JsonConvert.SerializeObject(wereDeletedEvent));
+            await _thirdPartyPushService.PushAsync(devices, "postermaster@aiursoft.com", JsonConvert.SerializeObject(friendDeletedEvent));
         }
 
         public async Task TimerUpdatedEvent(KahlaUser receiver, int newTimer, int conversationId)
@@ -161,6 +162,21 @@ namespace Kahla.Server.Services
             if (channel != -1)
             {
                 await _stargatePushService.PushMessageAsync(token, channel, JsonConvert.SerializeObject(dissolvevent), true);
+            }
+        }
+
+        public async Task GroupJoinedDissolveEvent(KahlaUser receiver, ContactInfo createdContact)
+        {
+            var token = await _appsContainer.AccessToken();
+            var channel = receiver.CurrentChannel;
+            var groupJoinedEvent = new GroupJoinedEvent
+            {
+                CreatedContact = createdContact
+            };
+
+            if (channel != -1)
+            {
+                await _stargatePushService.PushMessageAsync(token, channel, JsonConvert.SerializeObject(groupJoinedEvent), true);
             }
         }
     }

--- a/Kahla.Server/Services/KahlaPushService.cs
+++ b/Kahla.Server/Services/KahlaPushService.cs
@@ -165,7 +165,7 @@ namespace Kahla.Server.Services
             }
         }
 
-        public async Task GroupJoinedDissolveEvent(KahlaUser receiver, ContactInfo createdContact)
+        public async Task GroupJoinedEvent(KahlaUser receiver, ContactInfo createdContact)
         {
             var token = await _appsContainer.AccessToken();
             var channel = receiver.CurrentChannel;

--- a/Kahla.Server/Services/KahlaPushService.cs
+++ b/Kahla.Server/Services/KahlaPushService.cs
@@ -89,12 +89,13 @@ namespace Kahla.Server.Services
             await _thirdPartyPushService.PushAsync(target.HisDevices, "postermaster@aiursoft.com", JsonConvert.SerializeObject(friendAcceptedEvent));
         }
 
-        public async Task WereDeletedEvent(int stargateChannel, IEnumerable<Device> devices, KahlaUser trigger)
+        public async Task WereDeletedEvent(int stargateChannel, IEnumerable<Device> devices, KahlaUser trigger, int deletedConversationId)
         {
             var token = await _appsContainer.AccessToken();
             var wereDeletedEvent = new WereDeletedEvent
             {
-                Trigger = trigger
+                Trigger = trigger,
+                ConversationId = deletedConversationId
             };
             if (stargateChannel != -1)
             {

--- a/Kahla.Server/Services/KahlaPushService.cs
+++ b/Kahla.Server/Services/KahlaPushService.cs
@@ -4,7 +4,6 @@ using Aiursoft.SDK.Services;
 using Aiursoft.SDK.Services.ToStargateServer;
 using Kahla.SDK.Events;
 using Kahla.SDK.Models;
-using Kahla.SDK.Models.ApiViewModels;
 using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -165,13 +164,13 @@ namespace Kahla.Server.Services
             }
         }
 
-        public async Task GroupJoinedEvent(KahlaUser receiver, ContactInfo createdContact)
+        public async Task GroupJoinedEvent(KahlaUser receiver, GroupConversation createdConversation)
         {
             var token = await _appsContainer.AccessToken();
             var channel = receiver.CurrentChannel;
             var groupJoinedEvent = new GroupJoinedEvent
             {
-                CreatedContact = createdContact
+                CreatedConversation = createdConversation
             };
 
             if (channel != -1)

--- a/Kahla.Server/Services/KahlaPushService.cs
+++ b/Kahla.Server/Services/KahlaPushService.cs
@@ -164,13 +164,15 @@ namespace Kahla.Server.Services
             }
         }
 
-        public async Task GroupJoinedEvent(KahlaUser receiver, GroupConversation createdConversation)
+        public async Task GroupJoinedEvent(KahlaUser receiver, GroupConversation createdConversation, Message latestMessage, int messageCount)
         {
             var token = await _appsContainer.AccessToken();
             var channel = receiver.CurrentChannel;
             var groupJoinedEvent = new GroupJoinedEvent
             {
-                CreatedConversation = createdConversation
+                CreatedConversation = createdConversation,
+                LatestMessage = latestMessage,
+                MessageCount = messageCount
             };
 
             if (channel != -1)

--- a/Kahla.Server/Services/KahlaPushService.cs
+++ b/Kahla.Server/Services/KahlaPushService.cs
@@ -89,10 +89,10 @@ namespace Kahla.Server.Services
             await _thirdPartyPushService.PushAsync(target.HisDevices, "postermaster@aiursoft.com", JsonConvert.SerializeObject(friendAcceptedEvent));
         }
 
-        public async Task WereDeletedEvent(int stargateChannel, IEnumerable<Device> devices, KahlaUser trigger, int deletedConversationId)
+        public async Task FriendDeletedEvent(int stargateChannel, IEnumerable<Device> devices, KahlaUser trigger, int deletedConversationId)
         {
             var token = await _appsContainer.AccessToken();
-            var wereDeletedEvent = new WereDeletedEvent
+            var wereDeletedEvent = new FriendDeletedEvent
             {
                 Trigger = trigger,
                 ConversationId = deletedConversationId


### PR DESCRIPTION
Merging this will cause the current app to stop working. It causes lots' of breaking changes. But those changes help the client-side to sync all data to the latest. So the conversation list can be always up to date without calling any API.

* `NewFriendRequest` event will directly return the `Request` object
* Refactored event `FriendAcceptedEvent`, renamed to `FriendsChangedEvent`. It will be triggered when any of your associated friend requests change, whether you sent it to you, whether it was approved or rejected
* The `conversation/all` API will return the entity of the last message in this conversation and will carry the sender information
* Kahla Bot's `OnMessage` event will now be triggered by new group invitations
* Refactored `WereDeletedEvent` and renamed it to `FriendDeletedEvent`. The deleted conversation ID will now be returned. And both the trigger person and the deleted person will push.
* Added event type `GroupJoinedEvent`. Triggered when you join a group, it will return a `createdConversation`, a `messageCount`, a `latestMessage`.


Chinese version (Might be easier for native speaker to review):

* NewFriendRequest事件会直接把Request对象返回
* 重构事件FriendAcceptedEvent，重命名为FriendsChangedEvent，任何你关联的好友请求发生变化时都会触发，无论是你发的还是发给你的，无论同意了还是拒绝了
* conversation/all API会返回这个会话里最后一条消息的实体，且会携带发送人信息
* Kahla Bot的OnMessage事件现在会被新群邀请触发
* 重构WereDeletedEvent，重命名为FriendDeletedEvent。现在会返回删除掉的会话ID了。且对于触发人和被删除人双方都会推送。
* 新增事件类型 GroupJoinedEvent。当你加入一个群时触发，会返回一个GroupConversation，一个messageCount，一个latestMessage。
